### PR TITLE
feat: claude-tmux CLI 추가 및 Homebrew 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # claude-tmux-session
 
-Claude Code tmux session manager for zsh.
+Claude Code tmux session manager for zsh (macOS).
 
 Automatically runs `claude` inside a tmux session and offers to resume your previous session when you return to the same directory within 5 minutes.
 
 ## Features
 
 - Runs `claude` inside a named tmux session automatically
-- Detects previous session when reopening in the same directory
-- Prompts `y/n` to resume within a 5-minute window
+- Lists previous sessions when reopening in the same directory within 5 minutes
+- Supports multiple sessions per directory
 - Session auto-expires after 5 minutes of inactivity
 - Works inside existing tmux sessions without nesting
 
@@ -16,14 +16,28 @@ Automatically runs `claude` inside a tmux session and offers to resume your prev
 
 - [tmux](https://github.com/tmux/tmux)
 - [Claude Code](https://claude.ai/code)
-- zsh
+- zsh (macOS)
 
 ## Installation
 
-Add to your `~/.zshrc`:
+### Homebrew (recommended)
 
 ```zsh
-source <(curl -s https://raw.githubusercontent.com/kungbi/claude-tmux-session/main/claude-tmux-session.zsh)
+brew tap kungbi/tap
+brew install claude-tmux-session
+```
+
+Then add to `~/.zshrc`:
+
+```zsh
+source "$(brew --prefix)/share/claude-tmux-session/claude-tmux-session.zsh"
+```
+
+### Manual
+
+```zsh
+curl -fsSL https://raw.githubusercontent.com/kungbi/claude-tmux-session/main/install.sh | zsh
+source ~/.zshrc
 ```
 
 ## Usage
@@ -34,14 +48,29 @@ Just use `claude` as you normally would:
 claude
 ```
 
-When you return to the same directory within 5 minutes after closing, you'll see:
+When you return to the same directory within 5 minutes after closing, you'll see a session list:
 
 ```
-[claude] 이전 세션 발견: ~/your/project
-재개하시겠습니까? (y/n):
+[claude] 세션 목록: ~/your/project
+  [1] 2분 전
+  [2] 활성 세션
+  [n] 새 세션 생성
+  [q] 취소
+선택:
 ```
 
-Press `y` to resume, `n` to start a new session.
+Press a number to resume, `n` for a new session, or `q` to cancel.
+
+## CLI
+
+```zsh
+claude-tmux version   # 현재 버전 출력
+claude-tmux update    # 최신 버전으로 업데이트
+claude-tmux status    # 활성 세션 목록
+claude-tmux clean     # 만료된 stamp 파일 정리
+```
+
+`claude-tmux update`는 Homebrew로 설치된 경우 `brew upgrade`를 실행하고, 수동 설치의 경우 직접 다운로드합니다.
 
 ## Aliases
 

--- a/bin/claude-tmux
+++ b/bin/claude-tmux
@@ -1,0 +1,126 @@
+#!/bin/zsh
+# claude-tmux - Claude Code tmux session manager CLI
+
+_CLAUDE_TMUX_SCRIPT_URL="https://raw.githubusercontent.com/kungbi/claude-tmux-session/main/claude-tmux-session.zsh"
+_CLAUDE_TMUX_STAMP_DIR="${HOME}/.cache/claude-sessions"
+
+_ctm_install_path() {
+  local brew_prefix
+  brew_prefix=$(brew --prefix 2>/dev/null)
+  if [[ -n "$brew_prefix" && -f "${brew_prefix}/share/claude-tmux-session/claude-tmux-session.zsh" ]]; then
+    echo "${brew_prefix}/share/claude-tmux-session/claude-tmux-session.zsh"
+  elif [[ -f "${HOME}/.local/share/claude-tmux-session/claude-tmux-session.zsh" ]]; then
+    echo "${HOME}/.local/share/claude-tmux-session/claude-tmux-session.zsh"
+  fi
+}
+
+_ctm_is_brew() {
+  brew list claude-tmux-session &>/dev/null 2>&1
+}
+
+_ctm_version() {
+  local path version
+  path=$(_ctm_install_path)
+  [[ -n "$path" ]] && version=$(grep '^_CLAUDE_TMUX_VERSION=' "$path" 2>/dev/null | cut -d'"' -f2)
+  printf 'claude-tmux-session %s\n' "${version:-unknown}"
+}
+
+_ctm_update() {
+  if _ctm_is_brew; then
+    printf '\033[1;36m[claude-tmux]\033[0m Homebrew로 설치됨. 업그레이드 중...\n'
+    brew upgrade claude-tmux-session
+    return
+  fi
+
+  local install_path="${HOME}/.local/share/claude-tmux-session/claude-tmux-session.zsh"
+  local tmp current_version new_version
+  tmp=$(mktemp /tmp/claude-tmux-session.XXXXXX.zsh)
+  printf '\033[1;36m[claude-tmux]\033[0m 업데이트 확인 중...\n'
+
+  if ! curl -fsSL "$_CLAUDE_TMUX_SCRIPT_URL" -o "$tmp"; then
+    printf '\033[1;31m[claude-tmux]\033[0m 다운로드 실패\n'
+    rm -f "$tmp"
+    return 1
+  fi
+
+  current_version=$(grep '^_CLAUDE_TMUX_VERSION=' "$install_path" 2>/dev/null | cut -d'"' -f2)
+  new_version=$(grep '^_CLAUDE_TMUX_VERSION=' "$tmp" | cut -d'"' -f2)
+
+  if [[ "$new_version" == "$current_version" ]]; then
+    printf '\033[1;36m[claude-tmux]\033[0m 이미 최신 버전입니다 (%s)\n' "$current_version"
+    rm -f "$tmp"
+    return 0
+  fi
+
+  mkdir -p "${install_path:h}"
+  mv "$tmp" "$install_path"
+  printf '\033[1;32m[claude-tmux]\033[0m 업데이트 완료: %s → %s\n' "$current_version" "$new_version"
+  printf '\033[1;33m[claude-tmux]\033[0m 적용: source ~/.zshrc\n'
+}
+
+_ctm_status() {
+  local sessions
+  sessions=($(tmux list-sessions -F "#{session_name}" 2>/dev/null | grep "^claude_"))
+  if (( ${#sessions[@]} == 0 )); then
+    printf '활성 세션 없음\n'
+    return
+  fi
+  local now s saved elapsed mins secs
+  now=$(date +%s)
+  for s in "${sessions[@]}"; do
+    local stamp_file="${_CLAUDE_TMUX_STAMP_DIR}/$s"
+    if [[ -f "$stamp_file" ]]; then
+      saved=$(< "$stamp_file")
+      elapsed=$((now - saved))
+      mins=$(( elapsed / 60 ))
+      secs=$(( elapsed % 60 ))
+      if (( mins > 0 )); then
+        printf '%s (%d분 전)\n' "$s" "$mins"
+      else
+        printf '%s (%d초 전)\n' "$s" "$secs"
+      fi
+    else
+      printf '%s (활성)\n' "$s"
+    fi
+  done
+}
+
+_ctm_clean() {
+  local count=0 f sname
+  for f in "${_CLAUDE_TMUX_STAMP_DIR}"/claude_*(N); do
+    sname="${f##*/}"
+    if ! tmux has-session -t "$sname" 2>/dev/null; then
+      rm -f "$f"
+      count=$((count + 1))
+    fi
+  done
+  printf '%d개 stamp 파일 정리 완료\n' "$count"
+}
+
+case "$1" in
+  version|--version|-v)
+    _ctm_version
+    ;;
+  update|--update)
+    _ctm_update
+    ;;
+  status)
+    _ctm_status
+    ;;
+  clean)
+    _ctm_clean
+    ;;
+  ""|--help|-h)
+    printf 'Usage: claude-tmux <command>\n\n'
+    printf 'Commands:\n'
+    printf '  version   현재 버전 출력\n'
+    printf '  update    최신 버전으로 업데이트\n'
+    printf '  status    활성 세션 목록\n'
+    printf '  clean     만료된 stamp 파일 정리\n'
+    ;;
+  *)
+    printf 'Unknown command: %s\n' "$1" >&2
+    printf 'Run "claude-tmux --help" for usage.\n' >&2
+    exit 1
+    ;;
+esac

--- a/claude-tmux-session.zsh
+++ b/claude-tmux-session.zsh
@@ -1,51 +1,9 @@
 # claude-tmux-session.zsh
 # Claude Code tmux session manager (macOS)
 
-_CLAUDE_TMUX_VERSION="1.1.0"
-_CLAUDE_TMUX_SCRIPT_URL="https://raw.githubusercontent.com/kungbi/claude-tmux-session/main/claude-tmux-session.zsh"
-_CLAUDE_TMUX_LOCAL="${HOME}/.local/share/claude-tmux-session/claude-tmux-session.zsh"
-
-_claude_tmux_update() {
-  local tmp
-  tmp=$(mktemp /tmp/claude-tmux-session.XXXXXX.zsh)
-  printf '\033[1;36m[claude-tmux]\033[0m 업데이트 확인 중...\n'
-
-  if ! curl -fsSL "$_CLAUDE_TMUX_SCRIPT_URL" -o "$tmp" 2>/dev/null; then
-    printf '\033[1;31m[claude-tmux]\033[0m 다운로드 실패\n'
-    rm -f "$tmp"
-    return 1
-  fi
-
-  local new_version
-  new_version=$(grep '^_CLAUDE_TMUX_VERSION=' "$tmp" | cut -d'"' -f2)
-
-  if [[ "$new_version" == "$_CLAUDE_TMUX_VERSION" ]]; then
-    printf '\033[1;36m[claude-tmux]\033[0m 이미 최신 버전입니다 (%s)\n' "$_CLAUDE_TMUX_VERSION"
-    rm -f "$tmp"
-    return 0
-  fi
-
-  mkdir -p "${_CLAUDE_TMUX_LOCAL:h}"
-  mv "$tmp" "$_CLAUDE_TMUX_LOCAL"
-  source "$_CLAUDE_TMUX_LOCAL"
-
-  printf '\033[1;32m[claude-tmux]\033[0m 업데이트 완료: %s → %s\n' "$_CLAUDE_TMUX_VERSION" "$new_version"
-  printf '\033[1;33m[claude-tmux]\033[0m 영구 적용을 위해 ~/.zshrc의 source 라인을 변경하세요:\n'
-  printf '  source "%s"\n' "$_CLAUDE_TMUX_LOCAL"
-}
+_CLAUDE_TMUX_VERSION="1.2.0"
 
 _claude_tmux() {
-  case "$1" in
-    --update)
-      _claude_tmux_update
-      return
-      ;;
-    --version)
-      printf 'claude-tmux-session %s\n' "$_CLAUDE_TMUX_VERSION"
-      return
-      ;;
-  esac
-
   local dir_hash="claude_$(echo "$PWD" | md5 -q | head -c 8)"
   local stamp_dir="${HOME}/.cache/claude-sessions"
   local session_ttl=300

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,42 @@
+#!/bin/zsh
+# claude-tmux-session installer
+
+set -e
+
+SCRIPT_URL="https://raw.githubusercontent.com/kungbi/claude-tmux-session/main/claude-tmux-session.zsh"
+INSTALL_DIR="${HOME}/.local/share/claude-tmux-session"
+INSTALL_PATH="${INSTALL_DIR}/claude-tmux-session.zsh"
+ZSHRC="${ZDOTDIR:-$HOME}/.zshrc"
+SOURCE_LINE="source \"${INSTALL_PATH}\""
+
+_info()    { printf '\033[1;36m[claude-tmux]\033[0m %s\n' "$1"; }
+_success() { printf '\033[1;32m[claude-tmux]\033[0m %s\n' "$1"; }
+_warn()    { printf '\033[1;33m[claude-tmux]\033[0m %s\n' "$1"; }
+_error()   { printf '\033[1;31m[claude-tmux]\033[0m %s\n' "$1"; }
+
+if ! command -v tmux &>/dev/null; then
+  _error "tmux가 설치되어 있지 않습니다. brew install tmux"
+  exit 1
+fi
+if ! command -v claude &>/dev/null; then
+  _error "Claude Code가 설치되어 있지 않습니다. https://claude.ai/code"
+  exit 1
+fi
+
+_info "다운로드 중..."
+mkdir -p "$INSTALL_DIR"
+if ! curl -fsSL "$SCRIPT_URL" -o "$INSTALL_PATH"; then
+  _error "다운로드 실패"
+  exit 1
+fi
+
+if grep -qF "$SOURCE_LINE" "$ZSHRC" 2>/dev/null; then
+  _warn "이미 설치되어 있습니다 ($ZSHRC)"
+else
+  printf '\n# claude-tmux-session\n%s\n' "$SOURCE_LINE" >> "$ZSHRC"
+  _success "~/.zshrc에 추가 완료"
+fi
+
+_success "설치 완료!"
+_info "적용: source ~/.zshrc"
+_info "업데이트: claude-tmux update"


### PR DESCRIPTION
## 변경사항

### `bin/claude-tmux` CLI 추가

```zsh
claude-tmux version   # 현재 버전 출력
claude-tmux update    # 최신 버전으로 업데이트 (brew/수동 자동 감지)
claude-tmux status    # 활성 세션 목록
claude-tmux clean     # 만료된 stamp 파일 정리
```

### `claude-tmux-session.zsh` 정리
- 업데이트 로직 CLI로 이전 (`--update`, `--version` 플래그 제거)
- 버전 1.2.0

### `install.sh` 추가
- 로컬에 설치 + `.zshrc` source 라인 자동 추가

### Homebrew 지원
```zsh
brew tap kungbi/tap
brew install claude-tmux-session
```

### README 업데이트
- Homebrew 설치 방법 추가