### PR TITLE
fix: README 수정 및 리뷰 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Automatically runs `claude` inside a tmux session and offers to resume your prev
 ### Homebrew (recommended)
 
 ```zsh
-brew tap kungbi/tap
+brew tap kungbi/claude-tmux https://github.com/kungbi/kungbi-homebrew-claude-tmux
 brew install claude-tmux-session
 ```
 
@@ -64,13 +64,13 @@ Press a number to resume, `n` for a new session, or `q` to cancel.
 ## CLI
 
 ```zsh
-claude-tmux version   # 현재 버전 출력
-claude-tmux update    # 최신 버전으로 업데이트
-claude-tmux status    # 활성 세션 목록
-claude-tmux clean     # 만료된 stamp 파일 정리
+claude-tmux version   # show current version
+claude-tmux update    # update to latest version
+claude-tmux status    # list active sessions
+claude-tmux clean     # remove expired stamp files
 ```
 
-`claude-tmux update`는 Homebrew로 설치된 경우 `brew upgrade`를 실행하고, 수동 설치의 경우 직접 다운로드합니다.
+`claude-tmux update` runs `brew upgrade` when installed via Homebrew, or downloads directly for manual installs.
 
 ## Aliases
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Automatically runs `claude` inside a tmux session and offers to resume your prev
 ### Homebrew (recommended)
 
 ```zsh
-brew tap kungbi/claude-tmux https://github.com/kungbi/kungbi-homebrew-claude-tmux
+brew tap kungbi/claude-tmux
 brew install claude-tmux-session
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,16 @@ brew tap kungbi/claude-tmux
 brew install claude-tmux-session
 ```
 
-Then add to `~/.zshrc`:
+Add to `~/.zshrc` (also shown in post-install instructions):
 
 ```zsh
 source "$(brew --prefix)/share/claude-tmux-session/claude-tmux-session.zsh"
+```
+
+Then apply:
+
+```zsh
+source ~/.zshrc
 ```
 
 ### Manual
@@ -74,7 +80,7 @@ claude-tmux clean     # remove expired stamp files
 
 ## Aliases
 
-The plugin wraps the `claude` command. If you have aliases like `cc` or `ccc`, wrap them as well:
+Any alias that calls `claude` automatically goes through the session manager — no extra steps needed:
 
 ```zsh
 alias cc='claude --dangerously-skip-permissions'
@@ -83,7 +89,7 @@ alias ccc='claude --dangerously-skip-permissions --channels your-channel'
 
 ## Tip: Hide tmux status bar
 
-If you don't want the tmux status bar to appear, add this to `~/.tmux.conf`:
+Add to `~/.tmux.conf`:
 
 ```
 set -g status off

--- a/bin/claude-tmux
+++ b/bin/claude-tmux
@@ -35,11 +35,11 @@ _ctm_update() {
   local install_path="${HOME}/.local/share/claude-tmux-session/claude-tmux-session.zsh"
   local tmp current_version new_version
   tmp=$(mktemp /tmp/claude-tmux-session.XXXXXX.zsh)
+  trap "rm -f '$tmp'" EXIT INT TERM
   printf '\033[1;36m[claude-tmux]\033[0m 업데이트 확인 중...\n'
 
   if ! curl -fsSL "$_CLAUDE_TMUX_SCRIPT_URL" -o "$tmp"; then
     printf '\033[1;31m[claude-tmux]\033[0m 다운로드 실패\n'
-    rm -f "$tmp"
     return 1
   fi
 
@@ -48,10 +48,10 @@ _ctm_update() {
 
   if [[ "$new_version" == "$current_version" ]]; then
     printf '\033[1;36m[claude-tmux]\033[0m 이미 최신 버전입니다 (%s)\n' "$current_version"
-    rm -f "$tmp"
     return 0
   fi
 
+  trap - EXIT INT TERM
   mkdir -p "${install_path:h}"
   mv "$tmp" "$install_path"
   printf '\033[1;32m[claude-tmux]\033[0m 업데이트 완료: %s → %s\n' "$current_version" "$new_version"

--- a/install.sh
+++ b/install.sh
@@ -4,10 +4,14 @@
 set -e
 
 SCRIPT_URL="https://raw.githubusercontent.com/kungbi/claude-tmux-session/main/claude-tmux-session.zsh"
+BIN_URL="https://raw.githubusercontent.com/kungbi/claude-tmux-session/main/bin/claude-tmux"
 INSTALL_DIR="${HOME}/.local/share/claude-tmux-session"
 INSTALL_PATH="${INSTALL_DIR}/claude-tmux-session.zsh"
+BIN_DIR="${HOME}/.local/bin"
+BIN_PATH="${BIN_DIR}/claude-tmux"
 ZSHRC="${ZDOTDIR:-$HOME}/.zshrc"
 SOURCE_LINE="source \"${INSTALL_PATH}\""
+PATH_LINE="export PATH=\"\${HOME}/.local/bin:\${PATH}\""
 
 _info()    { printf '\033[1;36m[claude-tmux]\033[0m %s\n' "$1"; }
 _success() { printf '\033[1;32m[claude-tmux]\033[0m %s\n' "$1"; }
@@ -24,10 +28,23 @@ if ! command -v claude &>/dev/null; then
 fi
 
 _info "다운로드 중..."
-mkdir -p "$INSTALL_DIR"
+mkdir -p "$INSTALL_DIR" "$BIN_DIR"
+
 if ! curl -fsSL "$SCRIPT_URL" -o "$INSTALL_PATH"; then
-  _error "다운로드 실패"
+  _error "다운로드 실패 (claude-tmux-session.zsh)"
   exit 1
+fi
+
+if ! curl -fsSL "$BIN_URL" -o "$BIN_PATH"; then
+  _error "다운로드 실패 (claude-tmux)"
+  exit 1
+fi
+chmod +x "$BIN_PATH"
+
+if grep -qF "$PATH_LINE" "$ZSHRC" 2>/dev/null || [[ ":$PATH:" == *":${BIN_DIR}:"* ]]; then
+  true
+else
+  printf '\n%s\n' "$PATH_LINE" >> "$ZSHRC"
 fi
 
 if grep -qF "$SOURCE_LINE" "$ZSHRC" 2>/dev/null; then


### PR DESCRIPTION
## 변경사항

- brew tap 명령어 수정 (`kungbi/tap` → `kungbi/claude-tmux`)
- README 언어 통일 (CLI 섹션 한국어 → 영어)
- Aliases 섹션 설명 명확화
- Homebrew 설치 단계 보완
- install.sh에 claude-tmux 바이너리 설치 추가
- _ctm_update에 trap 추가 (temp 파일 누수 방지)