### PR TITLE
docs: add cmux socket compatibility guide

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -12,7 +12,7 @@
 
 _`claude` 실행 → 터미널 닫기 → 돌아오기 → 이어서 작업._
 
-[설치](#설치) • [사용법](#사용법) • [CLI 레퍼런스](#cli)
+[설치](#설치) • [사용법](#사용법) • [CLI 레퍼런스](#cli) • [호환성](#호환성)
 
 <img width="620" alt="image" src="https://github.com/user-attachments/assets/7c5d486b-9d45-430f-8e55-cfed62ff80bd" />
 
@@ -120,33 +120,13 @@ source ~/.zshrc
 
 ### cmux
 
-[cmux](https://cmux.com)를 터미널 워크스페이스로 사용하는 경우, claude-tmux-session이 생성한 tmux 세션은 cmux의 프로세스 계층 외부에서 실행됩니다. cmux는 기본적으로 자신이 직접 spawn한 프로세스만 소켓 연결을 허용(`cmuxOnly` 모드)하기 때문에, tmux 세션 안에서 `cmux` CLI 명령어가 `Broken pipe` 에러와 함께 실패합니다.
-
-**증상**
-
-```
-Error: Failed to write to socket (Broken pipe, errno 32)
-```
-
-**원인**
-
-cmux의 소켓 접근 제어는 프로세스 ancestry 체크를 수행합니다. claude-tmux-session이 `claude`를 새 tmux 세션으로 감싸면, 해당 tmux 프로세스는 cmux의 직접 자식이 아니므로 소켓 연결이 거절됩니다.
-
-**해결 방법**
-
-cmux의 소켓 제어 모드를 `allowAll`로 변경하면 로컬의 모든 프로세스가 연결할 수 있습니다:
+[cmux](https://cmux.com)를 사용하는 경우, tmux 세션 안에서 `cmux` CLI가 동작하려면 아래 명령어를 한 번 실행하세요:
 
 ```zsh
 defaults write com.cmuxterm.app socketControlMode -string "allowAll"
 ```
 
-설정 후 cmux 앱을 재시작하면 tmux 세션 안에서도 `cmux` CLI 명령어가 정상 동작합니다.
-
-> **참고:** `allowAll` 모드는 동일 머신의 모든 프로세스가 cmux 소켓에 연결할 수 있게 합니다. 공유/신뢰할 수 없는 환경에서는 `password` 모드와 `CMUX_SOCKET_PASSWORD` 환경변수 사용을 권장합니다.
-
-**장기적 개선 제안 (cmux 메인테이너에게)**
-
-전역 설정 변경 없이도 tmux 안에서 cmux를 사용하는 케이스를 지원할 수 있도록, 워크스페이스 또는 세션 단위의 소켓 정책 설정을 제공해주세요.
+설정 후 cmux를 재시작하세요. 자세한 내용은 [PR #12](https://github.com/kungbi/claude-tmux-session/pull/12)를 참고하세요.
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -116,6 +116,38 @@ claude-tmux alias ct
 source ~/.zshrc
 ```
 
+## 호환성
+
+### cmux
+
+[cmux](https://cmux.com)를 터미널 워크스페이스로 사용하는 경우, claude-tmux-session이 생성한 tmux 세션은 cmux의 프로세스 계층 외부에서 실행됩니다. cmux는 기본적으로 자신이 직접 spawn한 프로세스만 소켓 연결을 허용(`cmuxOnly` 모드)하기 때문에, tmux 세션 안에서 `cmux` CLI 명령어가 `Broken pipe` 에러와 함께 실패합니다.
+
+**증상**
+
+```
+Error: Failed to write to socket (Broken pipe, errno 32)
+```
+
+**원인**
+
+cmux의 소켓 접근 제어는 프로세스 ancestry 체크를 수행합니다. claude-tmux-session이 `claude`를 새 tmux 세션으로 감싸면, 해당 tmux 프로세스는 cmux의 직접 자식이 아니므로 소켓 연결이 거절됩니다.
+
+**해결 방법**
+
+cmux의 소켓 제어 모드를 `allowAll`로 변경하면 로컬의 모든 프로세스가 연결할 수 있습니다:
+
+```zsh
+defaults write com.cmuxterm.app socketControlMode -string "allowAll"
+```
+
+설정 후 cmux 앱을 재시작하면 tmux 세션 안에서도 `cmux` CLI 명령어가 정상 동작합니다.
+
+> **참고:** `allowAll` 모드는 동일 머신의 모든 프로세스가 cmux 소켓에 연결할 수 있게 합니다. 공유/신뢰할 수 없는 환경에서는 `password` 모드와 `CMUX_SOCKET_PASSWORD` 환경변수 사용을 권장합니다.
+
+**장기적 개선 제안 (cmux 메인테이너에게)**
+
+전역 설정 변경 없이도 tmux 안에서 cmux를 사용하는 케이스를 지원할 수 있도록, 워크스페이스 또는 세션 단위의 소켓 정책 설정을 제공해주세요.
+
 ---
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -116,6 +116,38 @@ claude-tmux alias ct
 source ~/.zshrc
 ```
 
+## Compatibility
+
+### cmux
+
+If you use [cmux](https://cmux.com) as your terminal workspace, the tmux session created by claude-tmux-session runs outside cmux's process ancestry. By default, cmux only allows socket connections from processes it directly spawned (`cmuxOnly` mode), which causes `cmux` CLI commands to fail with a `Broken pipe` error inside the tmux session.
+
+**Symptoms**
+
+```
+Error: Failed to write to socket (Broken pipe, errno 32)
+```
+
+**Root cause**
+
+cmux's socket access control performs a process ancestry check. When claude-tmux-session wraps `claude` inside a new tmux session, that tmux process is not a direct child of cmux, so the socket connection is rejected.
+
+**Fix**
+
+Change cmux's socket control mode to `allowAll` so that any local process can connect:
+
+```zsh
+defaults write com.cmuxterm.app socketControlMode -string "allowAll"
+```
+
+Then restart the cmux app. After restarting, `cmux` CLI commands will work normally inside tmux sessions.
+
+> **Note:** `allowAll` permits any process on the same machine to connect to the cmux socket. If you are in a shared or untrusted environment, consider using `password` mode instead and setting `CMUX_SOCKET_PASSWORD`.
+
+**Suggested long-term fix (for cmux maintainers)**
+
+Expose a per-workspace or per-session socket policy so users who intentionally run tmux inside cmux are not blocked without a global setting change.
+
 ---
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ English | [한국어](README.ko.md)
 
 _Run `claude`. Close your terminal. Come back. Pick up where you left off._
 
-[Installation](#installation) • [Usage](#usage) • [CLI Reference](#cli)
+[Installation](#installation) • [Usage](#usage) • [CLI Reference](#cli) • [Compatibility](#compatibility)
 
 <img width="620" alt="image" src="https://github.com/user-attachments/assets/7c5d486b-9d45-430f-8e55-cfed62ff80bd" />
 
@@ -120,33 +120,13 @@ source ~/.zshrc
 
 ### cmux
 
-If you use [cmux](https://cmux.com) as your terminal workspace, the tmux session created by claude-tmux-session runs outside cmux's process ancestry. By default, cmux only allows socket connections from processes it directly spawned (`cmuxOnly` mode), which causes `cmux` CLI commands to fail with a `Broken pipe` error inside the tmux session.
-
-**Symptoms**
-
-```
-Error: Failed to write to socket (Broken pipe, errno 32)
-```
-
-**Root cause**
-
-cmux's socket access control performs a process ancestry check. When claude-tmux-session wraps `claude` inside a new tmux session, that tmux process is not a direct child of cmux, so the socket connection is rejected.
-
-**Fix**
-
-Change cmux's socket control mode to `allowAll` so that any local process can connect:
+If you use [cmux](https://cmux.com), run this once to allow `cmux` CLI commands inside tmux sessions created by claude-tmux-session:
 
 ```zsh
 defaults write com.cmuxterm.app socketControlMode -string "allowAll"
 ```
 
-Then restart the cmux app. After restarting, `cmux` CLI commands will work normally inside tmux sessions.
-
-> **Note:** `allowAll` permits any process on the same machine to connect to the cmux socket. If you are in a shared or untrusted environment, consider using `password` mode instead and setting `CMUX_SOCKET_PASSWORD`.
-
-**Suggested long-term fix (for cmux maintainers)**
-
-Expose a per-workspace or per-session socket policy so users who intentionally run tmux inside cmux are not blocked without a global setting change.
+Then restart cmux. See [PR #12](https://github.com/kungbi/claude-tmux-session/pull/12) for details.
 
 ---
 


### PR DESCRIPTION
## Issue

When using `claude-tmux-session` inside [cmux](https://cmux.com), all `cmux` CLI commands fail with the following error inside the tmux session:

```
Error: Failed to write to socket (Broken pipe, errno 32)
```

## Root Cause

cmux's socket access control performs a **process ancestry check**. By default, it operates in `cmuxOnly` mode — only processes directly spawned by cmux are allowed to connect to the socket.

When `claude-tmux-session` wraps `claude` inside a new `tmux new-session`, that tmux process is no longer a direct child of cmux. The ancestry check fails, and the socket connection is rejected, resulting in `Broken pipe`.

Environment variables like `CMUX_WORKSPACE_ID` are present (inherited or passed via `-e`), but `CMUX_SURFACE_ID` is empty — which is a signal that the process is not recognized as a cmux-owned surface. However, the real blocker is the socket control mode, not the missing variable.

## Fix

Change cmux's socket control mode to `allowAll`:

```zsh
defaults write com.cmuxterm.app socketControlMode -string "allowAll"
```

Restart cmux after applying. After this, `cmux` CLI commands work normally inside tmux sessions created by `claude-tmux-session`.

## Suggested Long-Term Fix (for cmux)
@kungbi @backend-woongbi 
Expose a per-workspace or per-session socket policy so users who intentionally run tmux inside cmux are not blocked without a global setting change.

## Changes
- Added **Compatibility** section to `README.md` and `README.ko.md` documenting:
  - Symptoms
  - Root cause explanation
  - One-line fix with `defaults write`
  - Security note about `allowAll` vs `password` mode
  - Long-term suggestion for cmux maintainers